### PR TITLE
fix(flex): avoid generating unused yyinput by using %option noinput

### DIFF
--- a/src/omplexer.ll
+++ b/src/omplexer.ll
@@ -9,6 +9,7 @@
 %option prefix="openmp_"
 %option stack
 %option noyy_top_state
+%option noinput
 
 %x AFFINITY_EXPR_STATE
 %x AFFINITY_ITERATOR_STATE


### PR DESCRIPTION
Add %option noinput to avoid emitting unused yyinput/input in generated scanner; tidy CMakeLists.txt. Build/test: regenerated scanner and ran full test suite (136 tests passed).