### PR TITLE
Refine OpenMP lexer utilities and modernize parser

### DIFF
--- a/src/omplexer.ll
+++ b/src/omplexer.ll
@@ -90,23 +90,67 @@ extern int openmp_lex();
 extern void *(*exprParse)(const char *);
 
 #include "ompparser.hh"
+#include <algorithm>
+#include <cstring>
 #include <iostream>
 #include <stdio.h>
 #include <string>
-#include <string.h>
 
 /* Moved from Makefile.am to the source file to work with --with-pch Liao
    12/10/2009 */
 #define YY_NO_TOP_STATE
 #define YY_NO_POP_STATE
 
-static const char *ompparserinput = NULL;
+static const char *ompparserinput = nullptr;
 static std::string current_string;
 static int parenthesis_local_count = 0;
 static int parenthesis_global_count = 1;
 static int bracket_count;
 static int brace_count = 0;
 static char current_char;
+
+static void reset_expression_counters() {
+  parenthesis_local_count = 0;
+  parenthesis_global_count = 1;
+  bracket_count = 0;
+}
+
+static void prepare_expression_capture() {
+  current_string.clear();
+  reset_expression_counters();
+}
+
+static void prepare_expression_capture(char initial_char) {
+  prepare_expression_capture();
+  current_string.push_back(initial_char);
+}
+
+static int copy_from_input(char *buffer, int max_size) {
+  if (buffer == nullptr || max_size <= 0 || ompparserinput == nullptr ||
+      *ompparserinput == '\0') {
+    if (buffer != nullptr && max_size > 0) {
+      buffer[0] = '\0';
+    }
+    return 0;
+  }
+
+  if (max_size == 1) {
+    buffer[0] = '\0';
+    return 0;
+  }
+
+  const size_t chunk_size =
+      std::min(std::strlen(ompparserinput), static_cast<size_t>(max_size - 1));
+  if (chunk_size == 0) {
+    buffer[0] = '\0';
+    return 0;
+  }
+
+  std::memcpy(buffer, ompparserinput, chunk_size);
+  buffer[chunk_size] = '\0';
+  ompparserinput += chunk_size;
+  return static_cast<int>(chunk_size);
+}
 
 /* Liao 6/11/2010, OpenMP does not preclude the use of clause names as regular
    variable names. For example, num_threads could be a clause name or a
@@ -120,17 +164,21 @@ extern bool b_within_variable_list; /* = false; */
 /* pass user specified string to buf, indicate the size using 'result', and
    shift the current position pointer of user input afterwards to prepare next
    round of token recognition!! */
-#define YY_INPUT(buf, result, max_size)                                            \
-  {                                                                                \
-    if (*ompparserinput == '\0')                                                  \
-      result = 0;                                                                  \
-    else {                                                                         \
-      strncpy(buf, ompparserinput, max_size);                                      \
-      buf[(max_size) - 1] = '\0'; /* Ensure null termination within bounds */     \
-      result = strlen(buf);                                                        \
-      ompparserinput += result;                                                    \
-    }                                                                              \
-  }
+#define YY_INPUT(buf, result, max_size)                                         \
+  do {                                                                         \
+    result = copy_from_input(buf, max_size);                                   \
+  } while (0)
+
+#define RETURN_EXPR_TOKEN(token_char)                                           \
+  do {                                                                         \
+    openmp_lval.stype = strdup(current_string.c_str());                        \
+    current_string.clear();                                                    \
+    reset_expression_counters();                                               \
+    if ((token_char) != 0) {                                                   \
+      unput((token_char));                                                     \
+    }                                                                          \
+    return EXPR_STRING;                                                        \
+  } while (0)
 
 %}
 
@@ -316,7 +364,7 @@ sizes                     { return SIZES; }
 <ALLOCATE_STATE>")"                                   { yy_pop_state(); return ')'; }
 <ALLOCATE_STATE>":"                                   { return ':'; }
 <ALLOCATE_STATE>{blank}*                              { ; }
-<ALLOCATE_STATE>.                                     { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<ALLOCATE_STATE>.                                     { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <IF_STATE>parallel{blank}*/:                { return PARALLEL; }
 <IF_STATE>simd{blank}*/:                    { return SIMD; }
@@ -332,7 +380,7 @@ sizes                     { return SIZES; }
 <IF_STATE>")"                               { yy_pop_state(); return ')'; }
 <IF_STATE>":"                               { return ':'; }
 <IF_STATE>{blank}*                          { ; }
-<IF_STATE>.                                 { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<IF_STATE>.                                 { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 
 <PROC_BIND_STATE>master                     { return MASTER; }
@@ -376,7 +424,7 @@ sizes                     { return SIZES; }
 <REDUCTION_STATE>min/{blank}*:              { return MIN; }
 <REDUCTION_STATE>max/{blank}*:              { return MAX; }
 <REDUCTION_STATE>{blank}*                   { ; }
-<REDUCTION_STATE>.                          { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<REDUCTION_STATE>.                          { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <SIMD_STATE>"("                             { yy_push_state(EXPR_STATE); return '('; }
 <SIMD_STATE>")"                             { yy_pop_state(); return ')'; }
@@ -389,34 +437,34 @@ sizes                     { return SIZES; }
 <PRIVATE_STATE>"("                          { return '('; }
 <PRIVATE_STATE>")"                          { yy_pop_state(); return ')'; }
 <PRIVATE_STATE>{blank}*                     { ; }
-<PRIVATE_STATE>.                            { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<PRIVATE_STATE>.                            { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <FIRSTPRIVATE_STATE>"("                     { return '('; }
 <FIRSTPRIVATE_STATE>")"                     { yy_pop_state(); return ')'; }
 <FIRSTPRIVATE_STATE>{blank}*                { ; }
-<FIRSTPRIVATE_STATE>.                       { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<FIRSTPRIVATE_STATE>.                       { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <SHARED_STATE>"("                           { return '('; }
 <SHARED_STATE>")"                           { yy_pop_state(); return ')'; }
 <SHARED_STATE>{blank}*                      { ; }
-<SHARED_STATE>.                             { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<SHARED_STATE>.                             { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <COPYPRIVATE_STATE>"("                      { return '('; }
 <COPYPRIVATE_STATE>")"                      { yy_pop_state(); return ')'; }
 <COPYPRIVATE_STATE>{blank}*                 { ; }
-<COPYPRIVATE_STATE>.                        { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<COPYPRIVATE_STATE>.                        { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <COPYIN_STATE>"("                           { return '('; }
 <COPYIN_STATE>")"                           { yy_pop_state(); return ')'; }
 <COPYIN_STATE>{blank}*                      { ; }
-<COPYIN_STATE>.                             { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<COPYIN_STATE>.                             { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <LASTPRIVATE_STATE>conditional/{blank}*:    { return MODIFIER_CONDITIONAL; }
 <LASTPRIVATE_STATE>"("                      { return '('; }
 <LASTPRIVATE_STATE>")"                      { yy_pop_state(); return ')'; }
 <LASTPRIVATE_STATE>":"                      { return ':'; }
 <LASTPRIVATE_STATE>{blank}*                 { ; }
-<LASTPRIVATE_STATE>.                        { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<LASTPRIVATE_STATE>.                        { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <LINEAR_STATE>"("                           { return '('; }
 <LINEAR_STATE>")"                           { yy_pop_state(); return ')'; }
@@ -425,7 +473,7 @@ sizes                     { return SIZES; }
 <LINEAR_STATE>uval/{blank}*                 { return MODOFIER_UVAL; }
 <LINEAR_STATE>":"                           { return ':'; }
 <LINEAR_STATE>{blank}*                      { ; }
-<LINEAR_STATE>.                             { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<LINEAR_STATE>.                             { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 
 <SCHEDULE_STATE>monotonic                   { return MODIFIER_MONOTONIC; }
@@ -441,12 +489,12 @@ sizes                     { return SIZES; }
 <SCHEDULE_STATE>"("                         { return '('; }
 <SCHEDULE_STATE>")"                         { yy_pop_state(); return ')'; }
 <SCHEDULE_STATE>{blank}*                    { ; }
-<SCHEDULE_STATE>.                           { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<SCHEDULE_STATE>.                           { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <COLLAPSE_STATE>"("                         { return '('; }
 <COLLAPSE_STATE>")"                         { yy_pop_state(); return ')'; }
 <COLLAPSE_STATE>{blank}*                    { ; }
-<COLLAPSE_STATE>.                           { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<COLLAPSE_STATE>.                           { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <ORDERED_STATE>"("                          { yy_push_state(EXPR_STATE); return '('; }
 <ORDERED_STATE>")"                          { yy_pop_state(); return ')'; }
@@ -455,40 +503,40 @@ sizes                     { return SIZES; }
 <SIMDLEN_STATE>"("                          { return '('; }
 <SIMDLEN_STATE>")"                          { yy_pop_state(); return ')'; }
 <SIMDLEN_STATE>{blank}*                     { ; }
-<SIMDLEN_STATE>.                            { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<SIMDLEN_STATE>.                            { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <SAFELEN_STATE>"("                          { return '('; }
 <SAFELEN_STATE>")"                          { yy_pop_state(); return ')'; }
 <SAFELEN_STATE>{blank}*                     { ; }
-<SAFELEN_STATE>.                            { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<SAFELEN_STATE>.                            { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <NONTEMPORAL_STATE>"("                      { return '('; }
 <NONTEMPORAL_STATE>")"                      { yy_pop_state(); return ')'; }
 <NONTEMPORAL_STATE>{blank}*                 { ; }
-<NONTEMPORAL_STATE>.                        { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<NONTEMPORAL_STATE>.                        { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <NUM_TEAMS_STATE>"("                        { return '('; }
 <NUM_TEAMS_STATE>")"                        { yy_pop_state(); return ')'; }
 <NUM_TEAMS_STATE>{blank}*                   { ; }
-<NUM_TEAMS_STATE>.                          { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<NUM_TEAMS_STATE>.                          { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <NUM_THREADS_STATE>"("                      { return '('; }
 <NUM_THREADS_STATE>")"                      { yy_pop_state(); return ')'; }
 <NUM_THREADS_STATE>{blank}*                 { ; }
-<NUM_THREADS_STATE>.                        { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<NUM_THREADS_STATE>.                        { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <ALIGNED_STATE>"("                          { return '('; }
 <ALIGNED_STATE>":"                          { return ':'; }
 <ALIGNED_STATE>")"                          { yy_pop_state(); return ')'; }
 <ALIGNED_STATE>{blank}*                     { ; }
-<ALIGNED_STATE>.                            { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<ALIGNED_STATE>.                            { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <DIST_SCHEDULE_STATE>static/{blank}*        {return STATIC; }
 <DIST_SCHEDULE_STATE>"("                    { return '('; }
 <DIST_SCHEDULE_STATE>","                    { return ','; }
 <DIST_SCHEDULE_STATE>")"                    { yy_pop_state(); return ')'; }
 <DIST_SCHEDULE_STATE>{blank}*               { ; }
-<DIST_SCHEDULE_STATE>.                      { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<DIST_SCHEDULE_STATE>.                      { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <BIND_STATE>teams                           { return TEAMS; }
 <BIND_STATE>parallel                        { return PARALLEL; }
@@ -509,14 +557,14 @@ sizes                     { return SIZES; }
 <ALLOCATOR_STATE>{blank}*                   { ; }
 <ALLOCATOR_STATE>"("                        { return '('; }
 <ALLOCATOR_STATE>")"                        { yy_pop_state(); return ')'; }
-<ALLOCATOR_STATE>.                          { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<ALLOCATOR_STATE>.                          { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <INITIALIZER_STATE>omp_priv                 { return OMP_PRIV; }
 <INITIALIZER_STATE>"="                      { return '='; }
 <INITIALIZER_STATE>{blank}*                 { ; }
 <INITIALIZER_STATE>"("                      { return '('; }
 <INITIALIZER_STATE>")"                      { yy_pop_state(); return ')'; }
-<INITIALIZER_STATE>.                        { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<INITIALIZER_STATE>.                        { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <MAPPER_STATE>default                       { return IDENTIFIER_DEFAULT; }
 <MAPPER_STATE>"::"                          { return DOUBLE_COLON; }
@@ -524,7 +572,7 @@ sizes                     { return SIZES; }
 <MAPPER_STATE>{blank}*                      { ; }
 <MAPPER_STATE>"("                           { return '('; }
 <MAPPER_STATE>")"                           { yy_pop_state(); return ')'; }
-<MAPPER_STATE>.                             { yy_push_state(ID_EXPR_STATE); current_string = yytext[0]; }
+<MAPPER_STATE>.                             { yy_push_state(ID_EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <TYPE_STR_STATE>.                           { current_char = yytext[0];
                                             switch (current_char) {
@@ -581,7 +629,7 @@ sizes                     { return SIZES; }
 <WHEN_STATE>device                          { return DEVICE; }
 <WHEN_STATE>implementation                  { yy_push_state(IMPLEMENTATION_STATE); return IMPLEMENTATION; }
 <WHEN_STATE>{blank}*                        { ; }
-<WHEN_STATE>.                               { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<WHEN_STATE>.                               { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <IMPLEMENTATION_STATE>"("                            { return '('; }
 <IMPLEMENTATION_STATE>","                            { return ','; }
@@ -592,7 +640,7 @@ sizes                     { return SIZES; }
 <IMPLEMENTATION_STATE>vendor/{blank}*\(              { yy_push_state(VENDOR_STATE); return VENDOR; }
 <IMPLEMENTATION_STATE>extension/{blank}*\(           { yy_push_state(EXTENSION_STATE); return EXTENSION; }
 <IMPLEMENTATION_STATE>{blank}*                       { ; }
-<IMPLEMENTATION_STATE>.                              { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<IMPLEMENTATION_STATE>.                              { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <MATCH_STATE>"("                            { return '('; }
 <MATCH_STATE>":"                            { yy_push_state(INITIAL); return ':'; }
@@ -605,21 +653,21 @@ sizes                     { return SIZES; }
 <MATCH_STATE>device                         { return DEVICE; }
 <MATCH_STATE>implementation                 { yy_push_state(IMPLEMENTATION_STATE); return IMPLEMENTATION; }
 <MATCH_STATE>{blank}*                       { ; }
-<MATCH_STATE>.                              { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<MATCH_STATE>.                              { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <ISA_STATE>"("/score{blank}*\(              { return '('; }
 <ISA_STATE>"("                              { parenthesis_global_count = 1; return '('; }
 <ISA_STATE>")"                              { yy_pop_state(); return ')'; }
 <ISA_STATE>{blank}*                         { ; }
 <ISA_STATE>score/{blank}*\(                 { yy_push_state(SCORE_STATE); return SCORE; }
-<ISA_STATE>.                                { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<ISA_STATE>.                                { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <ARCH_STATE>"("/score{blank}*\(             { return '('; }
 <ARCH_STATE>"("                             { parenthesis_global_count = 1; return '('; }
 <ARCH_STATE>")"                             { yy_pop_state(); return ')'; }
 <ARCH_STATE>{blank}*                        { ; }
 <ARCH_STATE>score/{blank}*\(                { yy_push_state(SCORE_STATE); return SCORE; }
-<ARCH_STATE>.                               { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<ARCH_STATE>.                               { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <SCORE_STATE>"("{blank}*                    { yy_push_state(EXPR_STATE); parenthesis_global_count = 1; return '('; }
 <SCORE_STATE>")"                            { return ')'; }
@@ -631,7 +679,7 @@ sizes                     { return SIZES; }
 <CONDITION_STATE>")"                        { yy_pop_state(); return ')'; }
 <CONDITION_STATE>{blank}*                   { ; }
 <CONDITION_STATE>score/{blank}*\(           { yy_push_state(SCORE_STATE); return SCORE; }
-<CONDITION_STATE>.                          { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<CONDITION_STATE>.                          { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <VENDOR_STATE>"("                           { return '('; }
 <VENDOR_STATE>")"                           { yy_pop_state(); return ')'; }
@@ -653,7 +701,7 @@ sizes                     { return SIZES; }
 <EXTENSION_STATE>"("                        { return '('; }
 <EXTENSION_STATE>")"                        { yy_pop_state(); return ')'; }
 <EXTENSION_STATE>{blank}*                   { ; }
-<EXTENSION_STATE>.                          { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<EXTENSION_STATE>.                          { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <IN_REDUCTION_STATE>"("                     { return '('; }
 <IN_REDUCTION_STATE>")"                     { yy_pop_state(); return ')'; }
@@ -670,14 +718,14 @@ sizes                     { return SIZES; }
 <IN_REDUCTION_STATE>min/{blank}*:           { return MIN; }
 <IN_REDUCTION_STATE>max/{blank}*:           { return MAX; }
 <IN_REDUCTION_STATE>{blank}*                { ; }
-<IN_REDUCTION_STATE>.                       { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<IN_REDUCTION_STATE>.                       { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <DEPEND_STATE>"("                           { return '('; }
 <DEPEND_STATE>")"                           { yy_pop_state(); return ')'; }
 <DEPEND_STATE>","                           { return ','; }
 <DEPEND_STATE>"="                           { return '='; }
 <DEPEND_STATE>":"                           { yy_push_state(EXPR_STATE); return ':'; }
-<DEPEND_STATE>iterator/{blank}*"("          { current_string.clear(); yy_push_state(DEPEND_ITERATOR_STATE);return MODIFIER_ITERATOR; }
+<DEPEND_STATE>iterator/{blank}*"("          { prepare_expression_capture(); yy_push_state(DEPEND_ITERATOR_STATE);return MODIFIER_ITERATOR; }
 
 <DEPEND_STATE>in                            { return IN; }
 <DEPEND_STATE>out                           { return OUT; }
@@ -687,7 +735,7 @@ sizes                     { return SIZES; }
 <DEPEND_STATE>source                        { return SOURCE; }
 <DEPEND_STATE>sink                          { return SINK; }
 <DEPEND_STATE>{blank}*                      { ; }
-<DEPEND_STATE>.                             { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<DEPEND_STATE>.                             { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 <DEPEND_ITERATOR_STATE>"("                  { return '('; }
 <DEPEND_ITERATOR_STATE>"="                  { return '='; }
@@ -698,27 +746,27 @@ sizes                     { return SIZES; }
 <DEPEND_ITERATOR_STATE>.                    { yy_push_state(DEPEND_EXPR_STATE); unput(yytext[0]); }
 
 <DEPEND_EXPR_STATE>"("{blank}*              { return '('; }
-<DEPEND_EXPR_STATE>{blank}*")"              { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput(')'); return EXPR_STRING; }
-<DEPEND_EXPR_STATE>","                      { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput(','); return EXPR_STRING; } 
-<DEPEND_EXPR_STATE>{blank}                  { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); return EXPR_STRING; }
-<DEPEND_EXPR_STATE>"="                      { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput('='); return EXPR_STRING; }   
-<DEPEND_EXPR_STATE>":"                      { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput(':'); return EXPR_STRING; }
+<DEPEND_EXPR_STATE>{blank}*")"              { yy_pop_state(); RETURN_EXPR_TOKEN(')'); }
+<DEPEND_EXPR_STATE>","                      { yy_pop_state(); RETURN_EXPR_TOKEN(','); }
+<DEPEND_EXPR_STATE>{blank}                  { yy_pop_state(); RETURN_EXPR_TOKEN(0); }
+<DEPEND_EXPR_STATE>"="                      { yy_pop_state(); RETURN_EXPR_TOKEN('='); }
+<DEPEND_EXPR_STATE>":"                      { yy_pop_state(); RETURN_EXPR_TOKEN(':'); }
 <DEPEND_EXPR_STATE>.                        { current_string += yytext[0]; }
 
 <AFFINITY_STATE>"("                         { return '('; }
 <AFFINITY_STATE>")"                         { yy_pop_state(); return ')'; }
 <AFFINITY_STATE>","                         { return ','; }
 <AFFINITY_STATE>":"                         { return ':'; }
-<AFFINITY_STATE>iterator/{blank}*"("        { current_string.clear(); yy_push_state(AFFINITY_ITERATOR_STATE);return MODIFIER_ITERATOR; }
+<AFFINITY_STATE>iterator/{blank}*"("        { prepare_expression_capture(); yy_push_state(AFFINITY_ITERATOR_STATE);return MODIFIER_ITERATOR; }
 <AFFINITY_STATE>{blank}*                    { ; }
-<AFFINITY_STATE>.                           { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<AFFINITY_STATE>.                           { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 <AFFINITY_EXPR_STATE>"("{blank}*            { return '('; }
-<AFFINITY_EXPR_STATE>{blank}*")"            { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput(')'); return EXPR_STRING; }
-<AFFINITY_EXPR_STATE>{blank}                { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); return EXPR_STRING; }
-<AFFINITY_EXPR_STATE>","                    { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput(','); return EXPR_STRING; }
-<AFFINITY_EXPR_STATE>"="                    { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput('='); return EXPR_STRING; } 
-<AFFINITY_EXPR_STATE>":"                    { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput(':'); return EXPR_STRING; }
+<AFFINITY_EXPR_STATE>{blank}*")"            { yy_pop_state(); RETURN_EXPR_TOKEN(')'); }
+<AFFINITY_EXPR_STATE>{blank}                { yy_pop_state(); RETURN_EXPR_TOKEN(0); }
+<AFFINITY_EXPR_STATE>","                    { yy_pop_state(); RETURN_EXPR_TOKEN(','); }
+<AFFINITY_EXPR_STATE>"="                    { yy_pop_state(); RETURN_EXPR_TOKEN('='); }
+<AFFINITY_EXPR_STATE>":"                    { yy_pop_state(); RETURN_EXPR_TOKEN(':'); }
 <AFFINITY_EXPR_STATE>.                      { current_string += yytext[0]; }
 
 <AFFINITY_ITERATOR_STATE>"("                { return '('; }
@@ -732,7 +780,7 @@ sizes                     { return SIZES; }
 <FINAL_STATE>"("                            { return '('; }
 <FINAL_STATE>")"                            { yy_pop_state(); return ')'; }
 <FINAL_STATE>{blank}*                       { ; }
-<FINAL_STATE>.                              { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<FINAL_STATE>.                              { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <ATOMIC_DEFAULT_MEM_ORDER_STATE>seq_cst     { return SEQ_CST; }
 <ATOMIC_DEFAULT_MEM_ORDER_STATE>acq_rel     { return ACQ_REL; }
@@ -747,7 +795,7 @@ sizes                     { return SIZES; }
 <DEVICE_STATE>")"                           { yy_pop_state(); return ')'; }
 <DEVICE_STATE>":"                           { return ':'; }
 <DEVICE_STATE>{blank}*                      { ; }
-<DEVICE_STATE>.                             { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<DEVICE_STATE>.                             { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <DEFAULTMAP_STATE>alloc/{blank}*            { return BEHAVIOR_ALLOC; }
 <DEFAULTMAP_STATE>to/{blank}*               { return BEHAVIOR_TO; }
@@ -769,44 +817,44 @@ sizes                     { return SIZES; }
 <TO_STATE>")"                               { yy_pop_state(); return ')'; }
 <TO_STATE>","                               { return ','; }
 <TO_STATE>":"                               { return ':'; }
-<TO_STATE>mapper/{blank}*"("                { current_string.clear(); yy_push_state(TO_MAPPER_STATE);return TO_MAPPER; }
+<TO_STATE>mapper/{blank}*"("                { prepare_expression_capture(); yy_push_state(TO_MAPPER_STATE);return TO_MAPPER; }
 <TO_STATE>{blank}*                          { ; }
-<TO_STATE>.                                 { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<TO_STATE>.                                 { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 
 <TO_MAPPER_STATE>"("                        { return '('; }
 <TO_MAPPER_STATE>")"                        { yy_pop_state(); return ')'; }
-<TO_MAPPER_STATE>.                          { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<TO_MAPPER_STATE>.                          { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 <FROM_STATE>"("                             { return '('; }
 <FROM_STATE>")"                             { yy_pop_state(); return ')'; }
 <FROM_STATE>","                             { return ','; }
 <FROM_STATE>":"                             { return ':'; }
-<FROM_STATE>mapper/{blank}*"("              { current_string.clear(); yy_push_state(FROM_MAPPER_STATE);return FROM_MAPPER; }
+<FROM_STATE>mapper/{blank}*"("              { prepare_expression_capture(); yy_push_state(FROM_MAPPER_STATE);return FROM_MAPPER; }
 <FROM_STATE>{blank}*                        { ; }
-<FROM_STATE>.                               { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<FROM_STATE>.                               { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 <FROM_MAPPER_STATE>"("                      { return '('; }
 <FROM_MAPPER_STATE>")"                      { yy_pop_state(); return ')'; }
-<FROM_MAPPER_STATE>.                        { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<FROM_MAPPER_STATE>.                        { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 <USES_ALLOCATORS_STATE>"("                                     { return '('; }
 <USES_ALLOCATORS_STATE>","                                     { return ','; }
 <USES_ALLOCATORS_STATE>")"/{blank}*")"                         { yy_pop_state(); return ')'; }
 <USES_ALLOCATORS_STATE>")"                                     { return ')'; }
-<USES_ALLOCATORS_STATE>omp_default_mem_alloc/{blank}*"("       { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return DEFAULT_MEM_ALLOC; }
-<USES_ALLOCATORS_STATE>omp_large_cap_mem_alloc/{blank}*"("     { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return LARGE_CAP_MEM_ALLOC; }
-<USES_ALLOCATORS_STATE>omp_const_mem_alloc/{blank}*"("         { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return CONST_MEM_ALLOC; }
-<USES_ALLOCATORS_STATE>omp_high_bw_mem_alloc/{blank}*"("       { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return HIGH_BW_MEM_ALLOC; }
-<USES_ALLOCATORS_STATE>omp_low_lat_mem_alloc/{blank}*"("       { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return LOW_LAT_MEM_ALLOC; }
-<USES_ALLOCATORS_STATE>omp_cgroup_mem_alloc/{blank}*"("        { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return CGROUP_MEM_ALLOC; }
-<USES_ALLOCATORS_STATE>omp_pteam_mem_alloc/{blank}*"("         { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return PTEAM_MEM_ALLOC; }
-<USES_ALLOCATORS_STATE>omp_thread_mem_alloc/{blank}*"("        { current_string.clear(); yy_push_state(ALLOC_EXPR_STATE);return THREAD_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_default_mem_alloc/{blank}*"("       { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return DEFAULT_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_large_cap_mem_alloc/{blank}*"("     { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return LARGE_CAP_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_const_mem_alloc/{blank}*"("         { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return CONST_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_high_bw_mem_alloc/{blank}*"("       { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return HIGH_BW_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_low_lat_mem_alloc/{blank}*"("       { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return LOW_LAT_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_cgroup_mem_alloc/{blank}*"("        { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return CGROUP_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_pteam_mem_alloc/{blank}*"("         { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return PTEAM_MEM_ALLOC; }
+<USES_ALLOCATORS_STATE>omp_thread_mem_alloc/{blank}*"("        { prepare_expression_capture(); yy_push_state(ALLOC_EXPR_STATE);return THREAD_MEM_ALLOC; }
 <USES_ALLOCATORS_STATE>{blank}*                                { ; }
-<USES_ALLOCATORS_STATE>.                                       { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<USES_ALLOCATORS_STATE>.                                       { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 <ALLOC_EXPR_STATE>"("                        { return '('; }
-<ALLOC_EXPR_STATE>")"                        { yy_pop_state(); openmp_lval.stype = strdup(current_string.c_str()); current_string.clear(); unput(')'); return EXPR_STRING; }
+<ALLOC_EXPR_STATE>")"                        { yy_pop_state(); RETURN_EXPR_TOKEN(')'); }
 <ALLOC_EXPR_STATE>.                          { current_string += yytext[0]; }
 
 
@@ -820,7 +868,7 @@ sizes                     { return SIZES; }
 
 <MAP_STATE>always/{blank}*,                  { return MAP_MODIFIER_ALWAYS; }
 <MAP_STATE>close/{blank}*,                   { return MAP_MODIFIER_CLOSE; }
-<MAP_STATE>mapper/{blank}*"("                { current_string.clear(); yy_push_state(MAP_MAPPER_STATE);return MAP_MODIFIER_MAPPER; }
+<MAP_STATE>mapper/{blank}*"("                { prepare_expression_capture(); yy_push_state(MAP_MAPPER_STATE);return MAP_MODIFIER_MAPPER; }
 <MAP_STATE>"("                               { return '('; }
 <MAP_STATE>")"                               { yy_pop_state(); return ')'; }
 <MAP_STATE>","                               { return ','; }
@@ -832,11 +880,11 @@ sizes                     { return SIZES; }
 <MAP_STATE>release/{blank}*:                 { return MAP_TYPE_RELEASE; }
 <MAP_STATE>delete                            { return MAP_TYPE_DELETE; }
 <MAP_STATE>{blank}*                          { ; }
-<MAP_STATE>.                                 { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<MAP_STATE>.                                 { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <MAP_MAPPER_STATE>"("                        { return '('; }
 <MAP_MAPPER_STATE>")"                        { yy_pop_state(); return ')'; }
-<MAP_MAPPER_STATE>.                          { yy_push_state(EXPR_STATE); unput(yytext[0]); }
+<MAP_MAPPER_STATE>.                          { prepare_expression_capture(); yy_push_state(EXPR_STATE); unput(yytext[0]); }
 
 <TASK_REDUCTION_STATE>"("                     { return '('; }
 <TASK_REDUCTION_STATE>")"                     { yy_pop_state(); return ')'; }
@@ -853,7 +901,7 @@ sizes                     { return SIZES; }
 <TASK_REDUCTION_STATE>min/{blank}*:           { return MIN; }
 <TASK_REDUCTION_STATE>max/{blank}*:           { return MAX; }
 <TASK_REDUCTION_STATE>{blank}*                { ; }
-<TASK_REDUCTION_STATE>.                       { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+<TASK_REDUCTION_STATE>.                       { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 <UPDATE_STATE>"("                             { return '('; }
 <UPDATE_STATE>")"                             { yy_pop_state(); return ')'; }
@@ -1090,7 +1138,7 @@ sizes                     { return SIZES; }
 expr            {return (EXPRESSION); }
 
 {blank}*        ;
-.               { yy_push_state(EXPR_STATE); current_string = yytext[0]; }
+.               { yy_push_state(EXPR_STATE); prepare_expression_capture(yytext[0]); }
 
 %%
 

--- a/src/ompparser.yy
+++ b/src/ompparser.yy
@@ -39,10 +39,10 @@ extern void start_lexer(const char* input);
 extern void end_lexer(void);
 
 //The directive/clause that are being parsed
-static OpenMPDirective *current_directive = NULL;
-static OpenMPClause *current_clause = NULL;
-static OpenMPDirective *current_parent_directive = NULL;
-static OpenMPClause *current_parent_clause = NULL;
+static OpenMPDirective *current_directive = nullptr;
+static OpenMPClause *current_clause = nullptr;
+static OpenMPDirective *current_parent_directive = nullptr;
+static OpenMPClause *current_parent_clause = nullptr;
 static int firstParameter = 0;
 static int secondParameter = 0;
 static int thirdParameter = 0;
@@ -60,7 +60,7 @@ static const char *trait_score = "";
 /* Treat the entire expression as a string for now */
 extern void openmp_parse_expr();
 static int openmp_error(const char *);
-void *(*exprParse)(const char *) = NULL;
+void *(*exprParse)(const char *) = nullptr;
 
 bool b_within_variable_list =
     false; // a flag to indicate if the program is now processing a list of
@@ -307,8 +307,8 @@ end_directive : END { current_directive = new OpenMPEndDirective();
                 ((OpenMPEndDirective*)current_parent_directive)->setPairedDirective(current_directive);
                 current_directive = current_parent_directive;
                 current_clause = current_parent_clause;
-                current_parent_directive = NULL;
-                current_parent_clause = NULL;
+                current_parent_directive = nullptr;
+                current_parent_clause = nullptr;
               }
               ;
 
@@ -339,8 +339,8 @@ when_clause : WHEN { current_clause = current_directive->addOpenMPClause(OMPC_wh
                 } when_variant_directive {
                 current_directive = current_parent_directive;
                 current_clause = current_parent_clause;
-                current_parent_directive = NULL;
-                current_parent_clause = NULL;
+                current_parent_directive = nullptr;
+                current_parent_clause = nullptr;
                 } ')'
             ;
 
@@ -357,8 +357,8 @@ trait_set_selector : trait_set_selector_name { } '=' '{' trait_selector_list {
                         if (current_parent_clause) {
                             current_directive = current_parent_directive;
                             current_clause = current_parent_clause;
-                            current_parent_directive = NULL;
-                            current_parent_clause = NULL;
+                            current_parent_directive = nullptr;
+                            current_parent_clause = nullptr;
                         };
                      } '}'
                    ;
@@ -1139,9 +1139,9 @@ uses_allocators_parameter : allocators_list
                           | allocators_list ',' uses_allocators_parameter
                           ;
 
-allocators_list : allocators_list_parameter_enum { firstStringParameter = NULL; ((OpenMPUsesAllocatorsClause*)current_clause)->addUsesAllocatorsAllocatorSequence(usesAllocator, firstStringParameter, secondStringParameter); }
+allocators_list : allocators_list_parameter_enum { firstStringParameter = nullptr; ((OpenMPUsesAllocatorsClause*)current_clause)->addUsesAllocatorsAllocatorSequence(usesAllocator, firstStringParameter, secondStringParameter); }
                 | allocators_list_parameter_enum '(' EXPR_STRING ')' { firstStringParameter = $3; ((OpenMPUsesAllocatorsClause*)current_clause)->addUsesAllocatorsAllocatorSequence(usesAllocator, firstStringParameter, secondStringParameter); }
-                | allocators_list_parameter_user { usesAllocator = OMPC_USESALLOCATORS_ALLOCATOR_user; firstStringParameter = NULL; ((OpenMPUsesAllocatorsClause*)current_clause)->addUsesAllocatorsAllocatorSequence(usesAllocator, firstStringParameter, secondStringParameter); }
+                | allocators_list_parameter_user { usesAllocator = OMPC_USESALLOCATORS_ALLOCATOR_user; firstStringParameter = nullptr; ((OpenMPUsesAllocatorsClause*)current_clause)->addUsesAllocatorsAllocatorSequence(usesAllocator, firstStringParameter, secondStringParameter); }
                 | allocators_list_parameter_user '(' EXPR_STRING ')' { usesAllocator = OMPC_USESALLOCATORS_ALLOCATOR_user; firstStringParameter = $3; ((OpenMPUsesAllocatorsClause*)current_clause)->addUsesAllocatorsAllocatorSequence(usesAllocator, firstStringParameter, secondStringParameter); }
                 ;
 
@@ -3280,8 +3280,8 @@ default_variant_directive : { current_clause = current_directive->addOpenMPClaus
                             ((OpenMPDefaultClause*)current_parent_clause)->setVariantDirective(current_directive);
                             current_directive = current_parent_directive;
                             current_clause = current_parent_clause;
-                            current_parent_directive = NULL;
-                            current_parent_clause = NULL;
+                            current_parent_directive = nullptr;
+                            current_parent_clause = nullptr;
                             std::cout << "A construct directive has been added to DEFAULT clause.\n";
                             }
                           ;
@@ -3469,11 +3469,11 @@ schedule_enum_modifier : MODIFIER_MONOTONIC { firstParameter = OMPC_SCHEDULE_MOD
                        | MODIFIER_SIMD { firstParameter = OMPC_SCHEDULE_MODIFIER_simd; }
                        ;
 
-schedule_enum_kind : STATIC { if (current_directive!= NULL)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_static); }
-                   | DYNAMIC { if (current_directive!= NULL)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_dynamic); }
-                   | GUIDED { if (current_directive!= NULL)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_guided); }
-                   | AUTO { if (current_directive!= NULL)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_auto); }
-                   | RUNTIME { if (current_directive!= NULL)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_runtime); }
+schedule_enum_kind : STATIC { if (current_directive!= nullptr)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_static); }
+                   | DYNAMIC { if (current_directive!= nullptr)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_dynamic); }
+                   | GUIDED { if (current_directive!= nullptr)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_guided); }
+                   | AUTO { if (current_directive!= nullptr)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_auto); }
+                   | RUNTIME { if (current_directive!= nullptr)current_clause = current_directive->addOpenMPClause(OMPC_schedule, firstParameter, secondParameter, OMPC_SCHEDULE_KIND_runtime); }
                    ;  
 shared_clause : SHARED {
                 current_clause = current_directive->addOpenMPClause(OMPC_shared);
@@ -3525,7 +3525,7 @@ reduction_default_only_modifier : MODIFIER_DEFAULT { firstParameter = OMPC_REDUC
 int yyerror(const char *s) {
     // printf(" %s!\n", s);
     fprintf(stderr,"error: %s\n",s);
-    current_directive = NULL;
+    current_directive = nullptr;
     return 0;
 }
  
@@ -3537,7 +3537,7 @@ int yywrap()
 // Standalone ompparser
 OpenMPDirective* parseOpenMP(const char* _input, void * _exprParse(const char*)) {
     OpenMPBaseLang base_lang = Lang_C;
-    current_directive = NULL;
+    current_directive = nullptr;
     std::string input_string;  // Must persist until after start_lexer()
     const char *input = _input;
     std::regex fortran_regex ("[!cC*][$][Oo][Mm][Pp]");
@@ -3572,12 +3572,12 @@ OpenMPDirective* parseOpenMP(const char* _input, void * _exprParse(const char*))
             input = input_string.c_str();
             if (user_set_lang != Lang_Fortran){
                 yyerror("The language is set to C/C++, but the input is Fortran.");
-                return NULL;
+                return nullptr;
             }
         } else {
             if (user_set_lang == Lang_Fortran){
                 yyerror("The language is set to Fortran, but the input is C/C++.");
-                return NULL;
+                return nullptr;
             }
         }
     }


### PR DESCRIPTION
## Summary
- add helpers to reset expression capture state and deduplicate token cleanup in the lexer
- harden YY_INPUT against null pointers and reuse the helpers across expression-related states
- modernize the parser sources by switching NULL usages to nullptr

## Testing
- cmake --build build --target check

------
https://chatgpt.com/codex/tasks/task_e_68f00f495308832f92f8a91a4caa5df0