### PR TITLE
Treat C++ declare mapper syntax as C-like

### DIFF
--- a/src/ompparser.yy
+++ b/src/ompparser.yy
@@ -163,6 +163,15 @@ OpenMPBaseLang user_set_lang = Lang_unknown;
 OpenMPBaseLang auto_lang;
 void setLang(OpenMPBaseLang _lang) { user_set_lang = _lang; };
 
+static inline bool isCLikeOpenMPBaseLang(OpenMPBaseLang lang) {
+  return lang == Lang_C || lang == Lang_Cplusplus;
+}
+
+static inline bool parserLanguageIsCLike() {
+  return isCLikeOpenMPBaseLang(user_set_lang) ||
+         isCLikeOpenMPBaseLang(auto_lang);
+}
+
 /* used for clause normalization control */
 bool normalize_clauses_global = true;
 void setNormalizeClauses(bool normalize) { normalize_clauses_global = normalize; };
@@ -4614,7 +4623,7 @@ type_var : EXPR_STRING {
                    if (auto_lang == Lang_unknown) {
                        auto_lang = Lang_Fortran;
                    }
-               } else if (user_set_lang == Lang_C || auto_lang == Lang_C) { 
+               } else if (parserLanguageIsCLike()) {
                    int length = type_var.length() - 1;
                    for (int i = length; i >= 0; i--) {
                        if (type_var[i] == ' ' || type_var[i] == '*') { 
@@ -4633,7 +4642,7 @@ type_var : EXPR_STRING {
                    YYABORT; 
                }
          } 
-         | declare_mapper_type DOUBLE_COLON declare_mapper_var { if (user_set_lang == Lang_C || auto_lang == Lang_C) yyerror("The syntax should be \"type var\" in C"); YYABORT; }
+         | declare_mapper_type DOUBLE_COLON declare_mapper_var { if (parserLanguageIsCLike()) yyerror("The syntax should be \"type var\" in C"); YYABORT; }
          ;
          
 declare_mapper_type : EXPR_STRING { ((OpenMPDeclareMapperDirective*)current_directive)->setDeclareMapperType($1); }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,10 +36,14 @@ file(GLOB TEST_SUITE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/builtin/*.txt")
 list(SORT TEST_SUITE_FILES)
 foreach(TEST_FILE IN LISTS TEST_SUITE_FILES)
   get_filename_component(TEST_NAME "${TEST_FILE}" NAME_WE)
+  set(TEST_LANG_ARGS)
+  if(TEST_NAME MATCHES "_cplusplus$")
+    set(TEST_LANG_ARGS "--lang=c++")
+  endif()
   add_test(NAME builtin_${TEST_NAME}
            COMMAND ${CMAKE_COMMAND} -E env
                    "${OMPPARSER_TEST_LD_LIBRARY_PATH}"
-                   $<TARGET_FILE:tester> "${TEST_FILE}"
+                   $<TARGET_FILE:tester> ${TEST_LANG_ARGS} "${TEST_FILE}"
            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
 endforeach()
 

--- a/tests/builtin/declare_mapper_cplusplus.txt
+++ b/tests/builtin/declare_mapper_cplusplus.txt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018-2026, High Performance Computing Architecture and System
+ * research laboratory at University of North Carolina at Charlotte (HPCAS@UNCC)
+ * and Lawrence Livermore National Security, LLC.
+ *
+ * SPDX-License-Identifier: (BSD-3-Clause)
+ */
+
+//For testing purpose, there are several extra empty lines.
+//The final version should only contain necessary information.
+//This is not a C/C++ code, so there's no required writing style.
+//Only two kinds of special lines will be recognized.
+//One is starting with "omp", which is the input.
+//The other one is starting with "PASS: ", which is the result for validation.
+
+#pragma omp declare mapper(myvec_t v) map(v, v.data[0:v.len])
+PASS: #pragma omp declare mapper(myvec_t v) map(v, v.data[0:v.len])

--- a/tests/tester.cpp
+++ b/tests/tester.cpp
@@ -50,9 +50,24 @@ int openFile(std::ifstream &file, const char *filename) {
 int main(int argc, const char *argv[]) {
   const char *filename = nullptr;
   int result = -1;
+  OpenMPBaseLang default_base_lang = Lang_C;
 
-  if (argc > 1)
-    filename = argv[1];
+  for (int arg_idx = 1; arg_idx < argc; ++arg_idx) {
+    const std::string arg = argv[arg_idx];
+    if (arg == "--lang=c") {
+      default_base_lang = Lang_C;
+    } else if (arg == "--lang=c++" || arg == "--lang=cpp" ||
+               arg == "--lang=cxx") {
+      default_base_lang = Lang_Cplusplus;
+    } else if (arg == "--lang=fortran") {
+      default_base_lang = Lang_Fortran;
+    } else if (filename == nullptr) {
+      filename = argv[arg_idx];
+    } else {
+      std::cout << "Unexpected testing argument: " << arg << "\n";
+      return -1;
+    }
+  }
 
   std::ifstream input_file;
   std::ofstream output_file;
@@ -91,7 +106,7 @@ int main(int argc, const char *argv[]) {
   const std::string invalid_marker = "invalid test without paired validation.";
   bool expect_invalid_next = false;
   bool expect_invalid_block = false;
-  OpenMPBaseLang base_lang = Lang_C;
+  OpenMPBaseLang base_lang = default_base_lang;
 
   std::string filename_string = std::string(filename);
   filename_string = filename_string.substr(filename_string.rfind("/") + 1);
@@ -143,7 +158,7 @@ int main(int argc, const char *argv[]) {
       if (is_fortran_directive) {
         base_lang = Lang_Fortran;
       } else {
-        base_lang = Lang_C;
+        base_lang = default_base_lang;
       }
       setLang(base_lang);
 


### PR DESCRIPTION
## Summary

- Recognize `Lang_Cplusplus` anywhere `declare mapper` needs the C/C++ `type var` form.
- Centralize the parser-side C-like language check in enum-based helpers.
- Keep the regression in the existing builtin `.txt` harness by adding a C++ declare-mapper builtin test and an explicit builtin runner language option.

## Rationale

OpenMP `declare mapper` uses different type/variable spelling by base language: C and C++ use `type var`, while Fortran uses `type :: var`. The parser was checking only `Lang_C` in the C-like path, so callers that explicitly set `Lang_Cplusplus` could fail even though the input is valid C++ OpenMP syntax.

This change fixes the parser's language classification directly. It does not add unparser string workarounds or special-case the directive text.

## Testing

- `git diff --check`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target tester -j32`
- `ctest --test-dir build -R '^builtin_declare_mapper_cplusplus$' --output-on-failure`
- `ctest --test-dir build -R '^builtin_declare_mapper(_cplusplus|_fortran)?$' --output-on-failure`
- `cmake --build build --target check -j32`
  - 1527/1527 tests passed
