### PR TITLE
[codex] Fix OpenMP directive ownership cleanup

### DIFF
--- a/src/OpenMPIR.h
+++ b/src/OpenMPIR.h
@@ -283,6 +283,8 @@ public:
     normalize_clauses = normalize_clauses_global;
   };
 
+  virtual ~OpenMPDirective() = default;
+
   OpenMPDirectiveKind getKind() { return kind; };
 
   std::map<OpenMPClauseKind, std::vector<OpenMPClause *> *> *getAllClauses() {
@@ -421,12 +423,18 @@ public:
 
 class OpenMPEndDirective : public OpenMPDirective {
 protected:
-  OpenMPDirective *paired_directive;
+  OpenMPDirective *paired_directive = nullptr;
+  std::unique_ptr<OpenMPDirective> paired_directive_storage;
   bool use_compact_enddo = false;
 
 public:
   OpenMPEndDirective() : OpenMPDirective(OMPD_end) {};
+  void setPairedDirective(std::unique_ptr<OpenMPDirective> _paired_directive) {
+    paired_directive_storage = std::move(_paired_directive);
+    paired_directive = paired_directive_storage.get();
+  };
   void setPairedDirective(OpenMPDirective *_paired_directive) {
+    paired_directive_storage.reset();
     paired_directive = _paired_directive;
   };
   OpenMPDirective *getPairedDirective() { return paired_directive; };
@@ -1120,6 +1128,7 @@ protected:
 
   ScoredExpression user_condition_expression;
   std::vector<std::pair<std::string, OpenMPDirective *>> construct_directives;
+  std::vector<std::unique_ptr<OpenMPDirective>> construct_directive_storage;
   ScoredExpression arch_expression;
   ScoredExpression isa_expression;
   std::pair<std::string, OpenMPClauseContextKind> context_kind_name =
@@ -1145,8 +1154,22 @@ public:
   ScoredExpression *getUserCondition() { return &user_condition_expression; };
   void addConstructDirective(const char *_score,
                              OpenMPDirective *_construct_directive) {
+    if (_construct_directive == nullptr) {
+      return;
+    }
     construct_directives.push_back(
         std::make_pair(std::string(_score), _construct_directive));
+  };
+  void addConstructDirective(
+      const char *_score,
+      std::unique_ptr<OpenMPDirective> _construct_directive) {
+    if (_construct_directive == nullptr) {
+      return;
+    }
+    auto *construct_directive = _construct_directive.get();
+    construct_directive_storage.push_back(std::move(_construct_directive));
+    construct_directives.push_back(
+        std::make_pair(std::string(_score), construct_directive));
   };
   std::vector<std::pair<std::string, OpenMPDirective *>> *
   getConstructDirective() {
@@ -1224,11 +1247,17 @@ class OpenMPWhenClause : public OpenMPVariantClause {
 protected:
   OpenMPDirective *variant_directive =
       NULL; // variant directive inside the WHEN clause
+  std::unique_ptr<OpenMPDirective> variant_directive_storage;
 
 public:
   OpenMPWhenClause() : OpenMPVariantClause(OMPC_when) {};
   OpenMPDirective *getVariantDirective() { return variant_directive; };
+  void setVariantDirective(std::unique_ptr<OpenMPDirective> _variant_directive) {
+    variant_directive_storage = std::move(_variant_directive);
+    variant_directive = variant_directive_storage.get();
+  };
   void setVariantDirective(OpenMPDirective *_variant_directive) {
+    variant_directive_storage.reset();
     variant_directive = _variant_directive;
   };
 
@@ -1241,11 +1270,17 @@ class OpenMPOtherwiseClause : public OpenMPVariantClause {
 protected:
   OpenMPDirective *variant_directive =
       NULL; // variant directive inside the OTHERWISE clause
+  std::unique_ptr<OpenMPDirective> variant_directive_storage;
 
 public:
   OpenMPOtherwiseClause() : OpenMPVariantClause(OMPC_otherwise) {};
   OpenMPDirective *getVariantDirective() { return variant_directive; };
+  void setVariantDirective(std::unique_ptr<OpenMPDirective> _variant_directive) {
+    variant_directive_storage = std::move(_variant_directive);
+    variant_directive = variant_directive_storage.get();
+  };
   void setVariantDirective(OpenMPDirective *_variant_directive) {
+    variant_directive_storage.reset();
     variant_directive = _variant_directive;
   };
 
@@ -1302,6 +1337,7 @@ protected:
   OpenMPDefaultClauseKind default_kind = OMPC_DEFAULT_unknown;
   OpenMPDirective *variant_directive =
       NULL; // variant directive inside the DEFAULT clause
+  std::unique_ptr<OpenMPDirective> variant_directive_storage;
 
 public:
   OpenMPDefaultClause(OpenMPDefaultClauseKind _default_kind)
@@ -1310,7 +1346,12 @@ public:
   OpenMPDefaultClauseKind getDefaultClauseKind() { return default_kind; };
 
   OpenMPDirective *getVariantDirective() { return variant_directive; };
+  void setVariantDirective(std::unique_ptr<OpenMPDirective> _variant_directive) {
+    variant_directive_storage = std::move(_variant_directive);
+    variant_directive = variant_directive_storage.get();
+  };
   void setVariantDirective(OpenMPDirective *_variant_directive) {
+    variant_directive_storage.reset();
     variant_directive = _variant_directive;
   };
 

--- a/src/ompparser.yy
+++ b/src/ompparser.yy
@@ -16,11 +16,13 @@
 
 #include "OpenMPIR.h"
 
+#include <algorithm>
 #include <cctype>
 #include <cassert>
 #include <cstdio>
 #include <cstring>
 #include <iostream>
+#include <memory>
 #include <regex>
 #include <string>
 #include <utility>
@@ -45,6 +47,7 @@ static OpenMPDirective *current_directive = nullptr;
 static OpenMPClause *current_clause = nullptr;
 static OpenMPDirective *current_parent_directive = nullptr;
 static OpenMPClause *current_parent_clause = nullptr;
+static std::vector<std::unique_ptr<OpenMPDirective>> directive_storage;
 static std::vector<OpenMPApplyClause *> apply_clause_stack;
 static std::vector<OpenMPClauseSeparator> apply_clause_separator_stack;
 static int firstParameter = 0;
@@ -261,7 +264,9 @@ static std::string extractFortranOmpxPayloadPreserveCase(
 
 template <typename DirectiveType, typename... Args>
 static DirectiveType *makeDirectiveAt(int line, int column, Args &&...args) {
-  auto *directive = new DirectiveType(std::forward<Args>(args)...);
+  auto owned_directive =
+      std::make_unique<DirectiveType>(std::forward<Args>(args)...);
+  auto *directive = owned_directive.get();
   if (directive != nullptr) {
     if (line > 0) {
       directive->setLine(line);
@@ -270,7 +275,28 @@ static DirectiveType *makeDirectiveAt(int line, int column, Args &&...args) {
       directive->setColumn(column);
     }
   }
+  directive_storage.push_back(std::move(owned_directive));
   return directive;
+}
+
+static std::unique_ptr<OpenMPDirective>
+takeDirectiveOwnership(OpenMPDirective *directive) {
+  auto directive_iter =
+      std::find_if(directive_storage.begin(), directive_storage.end(),
+                   [directive](const std::unique_ptr<OpenMPDirective> &owned) {
+                     return owned.get() == directive;
+                   });
+  if (directive_iter == directive_storage.end()) {
+    return nullptr;
+  }
+
+  auto owned_directive = std::move(*directive_iter);
+  directive_storage.erase(directive_iter);
+  return owned_directive;
+}
+
+static OpenMPDirective *releaseDirectiveOwnership(OpenMPDirective *directive) {
+  return takeDirectiveOwnership(directive).release();
 }
 
 template <typename... Args>
@@ -780,7 +806,8 @@ end_directive : END { current_directive = makeDirectiveAt<OpenMPEndDirective>(@1
                 ((OpenMPEndDirective*)current_directive)
                     ->setUseCompactEndDo(openmp_consume_compact_enddo());
               } end_clause_seq {
-                ((OpenMPEndDirective*)current_parent_directive)->setPairedDirective(current_directive);
+                ((OpenMPEndDirective*)current_parent_directive)
+                    ->setPairedDirective(takeDirectiveOwnership(current_directive));
                 current_directive = current_parent_directive;
                 current_clause = current_parent_clause;
                 current_parent_directive = nullptr;
@@ -860,7 +887,10 @@ when_clause : WHEN { current_clause = addClauseAt(current_directive, @1.first_li
                 } ')'
             ;
 
-when_variant_directive : variant_directive {((OpenMPWhenClause*)current_parent_clause)->setVariantDirective(current_directive); }
+when_variant_directive : variant_directive {
+                    ((OpenMPWhenClause*)current_parent_clause)
+                        ->setVariantDirective(takeDirectiveOwnership(current_directive));
+                }
                 | { ; }
                 ;
 
@@ -894,7 +924,9 @@ trait_selector_list : trait_selector { trait_score = ""; }
 
 trait_selector : condition_selector
                 | construct_selector {
-                    ((OpenMPVariantClause*)current_parent_clause)->addConstructDirective(trait_score, current_directive);
+                    ((OpenMPVariantClause*)current_parent_clause)
+                        ->addConstructDirective(
+                            trait_score, takeDirectiveOwnership(current_directive));
                 }
                 | device_selector
                 | target_device_selector
@@ -1201,7 +1233,8 @@ target_region_boundary_opt : /* empty */
                                 OpenMPDirective *paired_target = current_directive;
                                 paired_target->setRequiresExplicitEnd(true);
                                 auto *end_directive = makeDirectiveAt<OpenMPEndDirective>(@1.first_line, @1.first_column);
-                                end_directive->setPairedDirective(paired_target);
+                                end_directive->setPairedDirective(
+                                    takeDirectiveOwnership(paired_target));
                                 current_directive = end_directive;
                                 current_clause = nullptr;
                              }
@@ -1673,7 +1706,8 @@ otherwise_clause : OTHERWISE {
                     current_parent_directive = current_directive;
                     current_parent_clause = current_clause;
                  } '(' variant_directive {
-                    ((OpenMPOtherwiseClause*)current_parent_clause)->setVariantDirective(current_directive);
+                    ((OpenMPOtherwiseClause*)current_parent_clause)
+                        ->setVariantDirective(takeDirectiveOwnership(current_directive));
                     current_directive = current_parent_directive;
                     current_clause = current_parent_clause;
                     current_parent_directive = nullptr;
@@ -5762,7 +5796,9 @@ default_variant_clause : DEFAULT '(' default_variant_directive ')' { }
 default_variant_directive : { current_clause = addClauseAt(current_directive, @$.first_line, @$.first_column, OMPC_default, OMPC_DEFAULT_variant);
                             current_parent_directive = current_directive;
                             current_parent_clause = current_clause; } variant_directive {
-                            ((OpenMPDefaultClause*)current_parent_clause)->setVariantDirective(current_directive);
+                            ((OpenMPDefaultClause*)current_parent_clause)
+                                ->setVariantDirective(
+                                    takeDirectiveOwnership(current_directive));
                             current_directive = current_parent_directive;
                             current_clause = current_parent_clause;
                             current_parent_directive = nullptr;
@@ -6351,6 +6387,10 @@ OpenMPDirective* parseOpenMP(const char* _input,
                              void *_exprParseUserData) {
     OpenMPBaseLang base_lang = Lang_C;
     current_directive = nullptr;
+    current_clause = nullptr;
+    current_parent_directive = nullptr;
+    current_parent_clause = nullptr;
+    directive_storage.clear();
     resetScheduleClauseLocationState();
     std::string input_string;  // Must persist until after start_lexer()
     const char *input = _input;
@@ -6407,10 +6447,23 @@ OpenMPDirective* parseOpenMP(const char* _input,
     openmpSetExprParseMode(OMP_EXPR_PARSE_none);
     openmp_reset_lexer_flags();
     start_lexer(input);
-    yyparse();
+    const int parse_result = yyparse();
     end_lexer();
-    if (current_directive) {
-        current_directive->setBaseLang(base_lang);
+    if (parse_result != 0 || current_directive == nullptr) {
+        current_directive = nullptr;
+        current_clause = nullptr;
+        current_parent_directive = nullptr;
+        current_parent_clause = nullptr;
+        directive_storage.clear();
+        return nullptr;
     }
-    return current_directive;
+
+    current_directive->setBaseLang(base_lang);
+    OpenMPDirective *result = releaseDirectiveOwnership(current_directive);
+    current_directive = nullptr;
+    current_clause = nullptr;
+    current_parent_directive = nullptr;
+    current_parent_clause = nullptr;
+    directive_storage.clear();
+    return result;
 }


### PR DESCRIPTION
## Summary

Fix ownership of parsed OpenMP directive IR nodes so clients can safely delete directives through the public `OpenMPDirective *` API and parser failures do not leak partially constructed ASTs.

## Root Cause

`parseOpenMP()` returns a base `OpenMPDirective *`, but the base class did not have a virtual destructor. Deleting a derived directive through that API can trigger AddressSanitizer `new-delete-type-mismatch`.

The parser also allocated directives directly with `new` while using global raw pointers during Bison parsing. If parsing aborted after partially constructing a directive, `yyerror()` cleared the current raw pointer and the allocation was lost. Nested directive nodes for `end`, `when`, `otherwise`, `default`, and construct selectors were also stored as raw pointers without owning lifetime.

## Changes

- Add a virtual destructor to `OpenMPDirective`.
- Make nested directive fields own their children with `std::unique_ptr` while preserving raw-pointer getters.
- Track directives allocated during a parse in parser-local ownership storage.
- Transfer ownership explicitly when directives become nested children or when `parseOpenMP()` returns the root directive to the caller.
- Clear parser-owned directive storage on parse failure so aborted parses do not leak partial ASTs.

## Validation

- `cmake --build build-codex-openmpdirective -j"$(nproc)"`
- `ctest --test-dir build-codex-openmpdirective -j"$(nproc)" --output-on-failure`
  - Passed: `1534/1534`
- `cmake --build build-codex-openmpdirective-asan -j"$(nproc)"`
- `ctest --test-dir build-codex-openmpdirective-asan -j"$(nproc)" --output-on-failure`
  - Passed: `1534/1534`