### PR TITLE
[codex] Upgrade CI to Ubuntu 26.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,17 +20,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        version: [9, 10, 11, 12, 13, 14]
+        os: [ubuntu-26.04]
+        version: [11, 12, 13, 14, 15, 16]
     env:
       CC: gcc-${{ matrix.version }}
       CXX: g++-${{ matrix.version }}
       FC: gfortran-${{ matrix.version }}
+      CLANG_FORMAT: clang-format
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           sudo apt-get update
-          sudo apt-get install -y cmake bison flex gcc-${{ matrix.version }} g++-${{ matrix.version }} gfortran-${{ matrix.version }}
+          sudo apt-get install -y cmake bison flex clang-format gcc-${{ matrix.version }} g++-${{ matrix.version }} gfortran-${{ matrix.version }}
+      - run: cmake -E rm -rf $BUILD_DIR
       - run: cmake -S . -B $BUILD_DIR -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
       - run: cmake --build $BUILD_DIR -- -j
       - name: Run built-in tests
@@ -45,20 +47,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04]
-        version: [17, 18, 19, 20, 21]
+        os: [ubuntu-26.04]
+        version: [21, 22]
     env:
       CC: clang-${{ matrix.version }}
       CXX: clang++-${{ matrix.version }}
       FC: flang-${{ matrix.version }}
+      CLANG_FORMAT: clang-format-${{ matrix.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/llvm-snapshot.asc > /dev/null
-          sudo add-apt-repository -y "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-${{ matrix.version }} main"
+          sudo apt-get update
+          sudo apt-get install -y ca-certificates gnupg wget
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor --yes -o /usr/share/keyrings/llvm-snapshot.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg] http://apt.llvm.org/resolute/ llvm-toolchain-resolute-${{ matrix.version }} main" | sudo tee /etc/apt/sources.list.d/llvm-toolchain-resolute-${{ matrix.version }}.list
       - run: |
           sudo apt-get update
           sudo apt-get install -y cmake bison flex clang-${{ matrix.version }} clang-format-${{ matrix.version }} flang-${{ matrix.version }}
+      - run: cmake -E rm -rf $BUILD_DIR
       - run: cmake -S . -B $BUILD_DIR -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON
       - run: cmake --build $BUILD_DIR -- -j
       - name: Run built-in tests
@@ -70,13 +76,14 @@ jobs:
 
   build-wasm:
     name: Build & Test (WASM)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           sudo apt-get update
-          sudo apt-get install -y cmake bison flex
-      - uses: mymindstorm/setup-emsdk@v14
+          sudo apt-get install -y cmake bison flex python-is-python3
+      - run: cmake -E rm -rf build-wasm
+      - uses: mymindstorm/setup-emsdk@v16
       - run: emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DOMPPARSER_ENABLE_WASM=ON
       - run: cmake --build build-wasm --target ompparser_wasm -- -j
       - name: Run WASM builtin tests
@@ -84,17 +91,18 @@ jobs:
 
   deploy-pages:
     name: Deploy gh-pages
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: [build-gcc, build-clang, build-wasm]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: |
           sudo apt-get update
-          sudo apt-get install -y cmake bison flex
-      - uses: mymindstorm/setup-emsdk@v14
+          sudo apt-get install -y cmake bison flex python-is-python3
+      - run: cmake -E rm -rf build-wasm
+      - uses: mymindstorm/setup-emsdk@v16
       - run: emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DOMPPARSER_ENABLE_WASM=ON
       - run: cmake --build build-wasm --target ompparser_wasm -- -j
       - name: Prepare gh-pages content

--- a/.github/workflows/codex-after-ci.yml
+++ b/.github/workflows/codex-after-ci.yml
@@ -25,7 +25,7 @@ jobs:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
     steps:
       - name: Debug workflow run info
         run: |


### PR DESCRIPTION
## Summary

This updates the CI workflow stack for Ubuntu 26.04 (`resolute`) and refreshes the GitHub Actions components to current major tags.

## Changes

- Move CI and Codex-after-CI runners from `ubuntu-24.04` / `ubuntu-latest` to `ubuntu-26.04`.
- Update the GCC test matrix to the compiler packages available on Ubuntu 26.04: GCC/G++/GFortran 11, 12, 13, 14, 15, and 16.
- Update the Clang test matrix to LLVM 21 and 22, matching the available `apt.llvm.org` `resolute` repositories.
- Replace the old LLVM `noble` apt setup with a signed-keyring `resolute` apt source.
- Refresh actions to latest major refs:
  - `actions/checkout@v7`
  - `mymindstorm/setup-emsdk@v16`
  - keep `peaceiris/actions-gh-pages@v4`, using the tracked major tag rather than pinning a minor release.
- Install `clang-format` in compiler jobs so round-trip formatting tests run consistently.
- Install `python-is-python3` in Emscripten jobs because `setup-emsdk@v16` invokes `python` directly.
- Remove stale build directories before configure so local `act` runs do not reuse copied build trees.

## Rationale

Ubuntu 26.04 changes the available compiler set compared with the previous Noble-based workflow. LLVM 17-20 are not available from the `resolute` LLVM apt repositories, while LLVM 21 and 22 are. The GCC packages available on 26.04 cover 11 through 16. The workflow now reflects those package realities directly.

The Emscripten action update also exposed a runtime dependency on a `python` executable in the runner environment, so the WASM and deploy jobs now install `python-is-python3` explicitly.

## Validation

Validated locally with a custom Ubuntu 26.04 `act` runner image (`ompparser-act-ubuntu:26.04`):

- `act pull_request -W .github/workflows/ci.yml -j build-gcc -P ubuntu-26.04=ompparser-act-ubuntu:26.04 --pull=false`
- `act pull_request -W .github/workflows/ci.yml -j build-clang -P ubuntu-26.04=ompparser-act-ubuntu:26.04 --pull=false`
- `act pull_request -W .github/workflows/ci.yml -j build-wasm -P ubuntu-26.04=ompparser-act-ubuntu:26.04 --pull=false`
- `act --list -W .github/workflows/ci.yml && act --list -W .github/workflows/codex-after-ci.yml`
- workflow YAML parse with Python/PyYAML
- `git diff --check`
- stale-reference scan for old Ubuntu, LLVM Noble, and old action refs