### PR TITLE
[codex] Switch Pages deployment to Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,13 +89,14 @@ jobs:
       - name: Run WASM builtin tests
         run: node wasm/tests/run_wasm_builtin_tests.js --js build-wasm/wasm/ompparser.js --wasm build-wasm/wasm/ompparser.wasm
 
-  deploy-pages:
-    name: Deploy gh-pages
+  build-pages:
+    name: Build Pages
     runs-on: ubuntu-26.04
     needs: [build-gcc, build-clang, build-wasm]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
-      contents: write
+      contents: read
+      pages: write
     steps:
       - uses: actions/checkout@v7
       - run: |
@@ -105,18 +106,36 @@ jobs:
       - uses: mymindstorm/setup-emsdk@v16
       - run: emcmake cmake -S . -B build-wasm -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DOMPPARSER_ENABLE_WASM=ON
       - run: cmake --build build-wasm --target ompparser_wasm -- -j
-      - name: Prepare gh-pages content
+      - name: Prepare Pages content
         run: |
           rm -rf dist
           mkdir -p dist
-          cp -R web/* dist/
+          cp -R web/. dist/
           cp build-wasm/wasm/ompparser.js build-wasm/wasm/ompparser.wasm dist/
-      - name: Deploy to gh-pages
-        if: env.ACT != 'true'
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Configure GitHub Pages
+        if: ${{ !env.ACT }}
+        uses: actions/configure-pages@v6
+      - name: Upload Pages artifact
+        if: ${{ !env.ACT }}
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: dist
-          force_orphan: true
-          cname: ompparser.ouankou.com
+          path: dist
+
+  deploy-pages:
+    name: Deploy Pages
+    runs-on: ubuntu-26.04
+    needs: build-pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      actions: read
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        if: ${{ !env.ACT }}
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

This switches the website deployment workflow from the old `gh-pages` branch publishing model to GitHub Pages' artifact-based Actions deployment flow.

## What changed

- Replaced the previous `peaceiris/actions-gh-pages` deployment step that force-pushed `dist` to the `gh-pages` branch.
- Added a `build-pages` job that rebuilds the WASM site payload, prepares `dist`, configures Pages metadata, and uploads the static site with `actions/upload-pages-artifact@v5`.
- Added a dedicated `deploy-pages` job that deploys the uploaded artifact with `actions/deploy-pages@v5` through the `github-pages` environment.
- Used `actions/configure-pages@v6`, `actions/upload-pages-artifact@v5`, and `actions/deploy-pages@v5`, matching the working Actions-backed Pages pattern in `rex-ai/rex-cleanup`.
- Scoped permissions by job: `build-pages` gets `contents: read` plus `pages: write` for `configure-pages`; `deploy-pages` gets `actions: read`, `contents: read`, `pages: write`, and `id-token: write` so it can read artifact metadata and create the Pages deployment.
- Preserved the local `act` behavior used by the old deploy step and by `rex-cleanup`: configure, artifact upload, and deployment are skipped when `env.ACT` is set.
- Kept the deployment gated to pushes on `main` after the GCC, Clang, and WASM validation jobs finish.

## Why

The repository Pages settings have been switched from branch-based publishing to GitHub Actions publishing. The CI workflow still used the old `gh-pages` branch deployment action, so successful builds would continue publishing through the wrong mechanism and require `contents: write` access to update a branch.

Using the official Pages artifact/deploy actions matches the new repository setting, avoids force-pushing `gh-pages`, and uses the permission model GitHub expects for Actions-backed Pages deployments.

## Comparison against rex-cleanup

I compared this workflow against `/home/ouankou/Projects/rex-ai/rex-cleanup/.github/workflows/docs-publish.yml`, which already deploys via Actions-backed Pages.

The core deployment shape now matches:

- `actions/configure-pages@v6`
- `actions/upload-pages-artifact@v5`
- `actions/deploy-pages@v5`
- `github-pages` environment with `steps.deployment.outputs.page_url`
- `if: ${{ !env.ACT }}` guards around configure, upload, and deploy
- `pages: write` and `id-token: write` present where needed

One intentional difference is permission scoping. `rex-cleanup` grants Pages permissions at workflow scope because the workflow is dedicated to docs publishing. `ompparser` keeps this in the main CI workflow, so the Pages permissions are scoped to the two Pages jobs only. The deploy job also declares `actions: read` because `deploy-pages@v5` reads the uploaded Pages artifact metadata during deployment.

## Impact

For normal pushes to `main`, the site still builds from `web/` plus the generated `ompparser.js` and `ompparser.wasm` files. The difference is that GitHub Pages now serves the uploaded artifact from the `github-pages` deployment environment instead of reading from a `gh-pages` branch.

The custom domain remains controlled by the repository Pages settings for the Actions deployment path.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml YAML OK"'`
- `git diff --check`
- `/tmp/actionlint -ignore 'label "ubuntu-26\\.04" is unknown' .github/workflows/ci.yml`
- Compared Pages deploy structure with `/home/ouankou/Projects/rex-ai/rex-cleanup/.github/workflows/docs-publish.yml`
- Confirmed `actions/configure-pages@v6` calls the Pages API, so `build-pages` needs `pages: write` in real GitHub Actions runs and should be skipped under `act`
- Confirmed `actions/deploy-pages@v5` reads Pages artifact metadata, so `deploy-pages` needs `actions: read` when custom permissions are declared
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build --target check` passed 1534/1534 tests
- Docker Emscripten validation built `ompparser_wasm` and passed `node wasm/tests/run_wasm_builtin_tests.js --js build-wasm/wasm/ompparser.js --wasm build-wasm/wasm/ompparser.wasm`
- Real Pages payload assembly was checked locally and contained `index.html`, `app.js`, `styles.css`, `ompparser.js`, and `ompparser.wasm`.