### PR TITLE
Propagate directive language during clause adoption

### DIFF
--- a/src/OpenMPIR.cpp
+++ b/src/OpenMPIR.cpp
@@ -1585,6 +1585,9 @@ void OpenMPDirective::adoptClausesFrom(OpenMPDirective &source) {
     throw std::logic_error(
         "cannot adopt clauses from a directive in another base language");
   }
+  if (lang == Lang_unknown && source.lang != Lang_unknown) {
+    setBaseLang(source.lang);
+  }
   for (auto &entry : source.clauses) {
     auto &destination = clauses[entry.first];
     destination.insert(destination.end(), entry.second.begin(),
@@ -1611,7 +1614,7 @@ void OpenMPDirective::adoptClausesFrom(OpenMPDirective &source) {
     if (clause == nullptr) {
       throw std::logic_error("cannot adopt a null owned clause");
     }
-    clause->setBaseLang(lang != Lang_unknown ? lang : source.lang);
+    clause->setBaseLang(lang);
     clause_storage.push_back(std::move(clause));
   }
   source.clause_storage.clear();

--- a/tests/test_parser_api.cpp
+++ b/tests/test_parser_api.cpp
@@ -1578,6 +1578,22 @@ int main() {
     ok = false;
   }
 
+  OpenMPDirective clause_adoption_source(OMPD_target, Lang_C);
+  OpenMPClause *adopted_clause =
+      clause_adoption_source.addOpenMPClause(OMPC_nowait);
+  OpenMPDirective clause_adoption_destination(OMPD_target);
+  clause_adoption_destination.adoptClausesFrom(clause_adoption_source);
+  ompparser::ValidationResult clause_adoption_validation =
+      ompparser::validate(clause_adoption_destination);
+  if (clause_adoption_destination.getBaseLang() != Lang_C ||
+      adopted_clause == nullptr || adopted_clause->getBaseLang() != Lang_C ||
+      !clause_adoption_validation.success() ||
+      !clause_adoption_source.getAllClauses().empty() ||
+      !clause_adoption_source.getClausesInOriginalOrder()->empty()) {
+    std::cerr << "clause adoption did not propagate its exact base language\n";
+    ok = false;
+  }
+
   OpenMPDirective null_clause_ast(OMPD_parallel);
   bool null_clause_threw = false;
   try {


### PR DESCRIPTION
## Summary

- propagate an exact source directive language to an unknown-language destination before clause ownership is transferred
- assign adopted clauses from the destination's resolved language
- cover the unknown-destination/C-source adoption path with a parser API invariant test

## Root cause

`OpenMPDirective::adoptClausesFrom` previously copied the source language only to each moved clause. When the destination directive still had `Lang_unknown`, the resulting AST had C/C++/Fortran clauses owned by an unknown-language directive, and semantic validation correctly rejected that mismatch.

The destination language is now resolved first through `setBaseLang`, which also keeps any clauses already owned by the destination consistent. Existing cross-language adoption still hard-fails before mutation.

## Validation

- `ctest --test-dir build -R '^parser_api_invariants$' --output-on-failure`: 1/1 passed
- `ctest --test-dir build --output-on-failure -j64`: 1,536/1,536 passed
- `git diff --check`
- `clang-format` on both changed C++ files

This follows up the late review thread on #55 after that PR was merged.
